### PR TITLE
Add in-app PWA installation prompt and document overview

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -23,7 +23,7 @@ Each tab mounts into the shared `<main id="view">` element and drives its own UI
 - **data.js** – Presents a sortable table of raw combined data (date, solar kWh, home kWh, net, grid import/export) for the selected range. Shows helpful status messages when the range is empty or a backend request fails.
 - **record.js** – Allows manual entry of production readings. Displays the latest recorded values from Google Apps Script and submits form data back to the same endpoint, logging responses for troubleshooting.
 - **entry.js** – Provides an authenticated workflow for appending rows to a Google Sheet. Handles OAuth sign-in with Google Identity Services, reads the last populated row to calculate interpolation, and appends new rows with validation of production totals.
-- **settings.js** – Configures the SDGE ingestion workflow. After authenticating with Google Cloud scopes it uploads the selected SDGE export file to the configured Cloud Storage bucket, runs a follow-up BigQuery statement, and reports upload/query status back to the user.
+- **settings.js** – Configures the SDGE ingestion workflow. After authenticating with Google Cloud scopes it uploads the selected SDGE export file to the configured Cloud Storage bucket, runs a follow-up BigQuery statement, and reports upload/query status back to the user. It also surfaces the “Add to Home Screen” installer whenever the browser exposes the PWA prompt so mobile users can pin the app and run it without browser chrome.
 
 Tabs share date range changes via a `document` event so that selecting a range in one view keeps the others synchronized.
 

--- a/app.core.js
+++ b/app.core.js
@@ -1,5 +1,6 @@
 // app.core.js
 // Shared state, auth, Sheets, router, and lazy tab loader
+import './pwa-install.js';
 import { getDefaultDateRange } from './tabs/date-range.js';
 import {
   DEFAULT_BIGQUERY_PROJECT,

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#111827" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Electricity & Solar — Mobile</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icons/icon-192.png" />

--- a/pwa-install.js
+++ b/pwa-install.js
@@ -1,0 +1,71 @@
+const listeners = new Set();
+let deferredPrompt = null;
+
+function isStandaloneDisplay(){
+  if (typeof window === 'undefined') return false;
+  const standaloneMatchMedia = window.matchMedia ? window.matchMedia('(display-mode: standalone)') : null;
+  const navigatorStandalone = typeof window.navigator !== 'undefined' && 'standalone' in window.navigator
+    ? window.navigator.standalone
+    : false;
+  return Boolean((standaloneMatchMedia && standaloneMatchMedia.matches) || navigatorStandalone);
+}
+
+export function getPwaInstallState(){
+  return {
+    canInstall: Boolean(deferredPrompt),
+    isStandalone: isStandaloneDisplay(),
+  };
+}
+
+function notify(){
+  const snapshot = getPwaInstallState();
+  listeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch (err) {
+      console.error('PWA install listener error:', err);
+    }
+  });
+}
+
+export function onPwaInstallChange(listener){
+  if (typeof listener !== 'function') return () => {};
+  listeners.add(listener);
+  listener(getPwaInstallState());
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function triggerPwaInstall(){
+  if (!deferredPrompt){
+    throw new Error('Installation is not available yet.');
+  }
+  deferredPrompt.prompt();
+  const { outcome } = await deferredPrompt.userChoice;
+  deferredPrompt = null;
+  notify();
+  return outcome;
+}
+
+if (typeof window !== 'undefined'){
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    notify();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    notify();
+  });
+
+  if (window.matchMedia){
+    const media = window.matchMedia('(display-mode: standalone)');
+    if (media && typeof media.addEventListener === 'function'){
+      media.addEventListener('change', notify);
+    } else if (media && typeof media.addListener === 'function'){
+      media.addListener(notify);
+    }
+  }
+}

--- a/tabs/settings.js
+++ b/tabs/settings.js
@@ -9,6 +9,11 @@ import {
   DEFAULT_BIGQUERY_SQL,
   GOOGLE_OAUTH_CLIENT_ID,
 } from './cloud-config.js';
+import {
+  getPwaInstallState,
+  onPwaInstallChange,
+  triggerPwaInstall,
+} from '../pwa-install.js';
 
 const CLOUD_SCOPE_STRING = CLOUD_SCOPES.join(' ');
 const GIS_SCRIPT_ID = 'google-identity-services';
@@ -244,6 +249,20 @@ export async function mount(root, ctx){
 
   root.innerHTML = `
     <section class="space-y-3">
+      <div class="card" id="installCard" hidden>
+        <div class="flex items-start gap-3">
+          <img src="icons/icon-192.png" alt="App icon" class="w-12 h-12 rounded-xl shadow-sm" />
+          <div class="flex-1">
+            <h2 class="font-semibold">Install on Your Device</h2>
+            <p class="text-sm text-gray-600">Add the Solar app to your Home Screen to launch it full screen without browser controls.</p>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 mt-3">
+          <button id="installAppBtn" class="px-3 py-1.5 rounded-lg bg-indigo-600 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed">Add to Home Screen</button>
+          <span id="installStatus" class="text-xs text-gray-600"></span>
+        </div>
+      </div>
+
       <div class="card">
         <h2 class="font-semibold mb-2">Rates</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -300,6 +319,10 @@ export async function mount(root, ctx){
   const saveRatesBtn = root.querySelector('#saveRatesBtn');
   const rateStatus = root.querySelector('#rateStatus');
 
+  const installCard = root.querySelector('#installCard');
+  const installButton = root.querySelector('#installAppBtn');
+  const installStatus = root.querySelector('#installStatus');
+
   const fileInput = root.querySelector('#cloudFileInput');
   const projectInput = root.querySelector('#bigQueryProject');
   const locationInput = root.querySelector('#bigQueryLocation');
@@ -314,6 +337,78 @@ export async function mount(root, ctx){
   if (projectInput) projectInput.value = state?.bigQueryProject || DEFAULT_BIGQUERY_PROJECT;
   if (locationInput) locationInput.value = state?.bigQueryLocation || DEFAULT_BIGQUERY_LOCATION;
   if (sqlInput) sqlInput.value = state?.bigQuerySql || DEFAULT_BIGQUERY_SQL;
+
+  function setInstallStatus(message, variant = 'info'){
+    if (!installStatus) return;
+    installStatus.textContent = message;
+    installStatus.className = 'text-xs';
+    if (variant === 'success') installStatus.classList.add('ok');
+    else if (variant === 'error') installStatus.classList.add('bad');
+    else installStatus.classList.add('text-gray-600');
+    installStatus.dataset.variant = variant;
+  }
+
+  function updateInstallUI(snapshot = getPwaInstallState()){
+    if (!installCard) return;
+    if (installCard.dataset.installed === 'true'){
+      installCard.hidden = true;
+      return;
+    }
+    const { canInstall, isStandalone } = snapshot;
+    if (isStandalone){
+      installCard.hidden = true;
+      return;
+    }
+    installCard.hidden = false;
+    if (installButton){
+      installButton.disabled = !canInstall;
+    }
+    const currentVariant = installStatus?.dataset?.variant;
+    if (!canInstall){
+      if (currentVariant !== 'success' && currentVariant !== 'error'){
+        setInstallStatus('The install prompt becomes available once the browser has finished preparing the app.', 'info');
+      }
+    } else if (currentVariant !== 'success' && currentVariant !== 'error'){
+      setInstallStatus('Tap "Add to Home Screen" to install the app without browser controls.', 'info');
+    }
+  }
+
+  let removeInstallListener = null;
+  const handleInstallChange = (snapshot) => {
+    if (!root.isConnected && typeof removeInstallListener === 'function'){
+      removeInstallListener();
+      removeInstallListener = null;
+      return;
+    }
+    updateInstallUI(snapshot);
+  };
+  removeInstallListener = onPwaInstallChange(handleInstallChange);
+
+  installButton?.addEventListener('click', async () => {
+    installButton.disabled = true;
+    setInstallStatus('Opening install prompt…', 'info');
+    try {
+      const outcome = await triggerPwaInstall();
+      if (outcome === 'accepted'){
+        setInstallStatus('Home Screen icon added. Launch the app from your Home Screen for a full screen experience.', 'success');
+        installCard.dataset.installed = 'true';
+        installCard.hidden = true;
+        return;
+      }
+      setInstallStatus('Installation was dismissed. You can try again later from this screen.', 'info');
+    } catch (err) {
+      console.error('PWA install error:', err);
+      setInstallStatus(err?.message || 'Installation failed.', 'error');
+    } finally {
+      const snapshot = getPwaInstallState();
+      if (snapshot.canInstall){
+        installButton.disabled = false;
+      }
+      if (!snapshot.isStandalone){
+        updateInstallUI(snapshot);
+      }
+    }
+  });
 
 
   function updateUploadButtonState(){


### PR DESCRIPTION
## Summary
- add a shared PWA installation helper that captures the deferred install prompt for reuse across tabs
- surface an "Add to Home Screen" card in the Settings tab with runtime status messaging and install button
- tighten mobile launch experience metadata and document the new installer entry point

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5cba289e48329800f99c3bf90196d