### PR TITLE
Fix PWA start URL for GitHub Pages

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,8 @@
 {
   "name": "Solar KPIs",
   "short_name": "Solar",
-  "start_url": "/index.html",
+  "start_url": "./index.html",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#111827",
   "theme_color": "#111827",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,9 +1,11 @@
-const CACHE='solar-pwa-v2';
-const CORE=[
-  '/index.html','/app.core.js',
-  '/tabs/kpi.js','/tabs/charts.js','/tabs/data.js','/tabs/settings.js',
-  '/icons/icon-192.png','/icons/icon-512.png','/manifest.webmanifest'
+const CACHE='solar-pwa-v3';
+const CORE_PATHS=[
+  'index.html','app.core.js',
+  'tabs/kpi.js','tabs/charts.js','tabs/data.js','tabs/settings.js',
+  'icons/icon-192.png','icons/icon-512.png','manifest.webmanifest'
 ];
+const BASE_PATH=self.location.pathname.replace(/service-worker\.js$/, '');
+const CORE=CORE_PATHS.map(path=>new URL(`${BASE_PATH}${path}`, self.location.origin).toString());
 self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE).then(c=>c.addAll(CORE)));});
 self.addEventListener('fetch',e=>{
   e.respondWith(


### PR DESCRIPTION
## Summary
- ensure the manifest starts the installed app from the repository path and scopes it to the Solar app directory
- update the service worker cache manifest to respect the deployed subdirectory so cached assets resolve correctly on GitHub Pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5d4bf19548329bb97e4c596d56509