### PR TITLE
Add top production day KPI highlight

### DIFF
--- a/tabs/daily-data-store.js
+++ b/tabs/daily-data-store.js
@@ -120,12 +120,22 @@ export async function ensureDailyDataLoaded(state){
 
 export function selectKpiMetrics(state){
   const rows = state?.dailyData?.rows || [];
+  let topProductionDay = null;
   const totals = rows.reduce((acc, row) => {
     acc.totalSolar += row.solarKWh;
     acc.totalUse += row.homeKWh;
     acc.totalImp += row.gridImport;
     acc.totalExp += row.gridExport;
     acc.dayCount += 1;
+
+    if (!topProductionDay || row.solarKWh > topProductionDay.solarKWh || (row.solarKWh === topProductionDay.solarKWh && row.date > topProductionDay.date)){
+      topProductionDay = {
+        date: row.date,
+        solarKWh: row.solarKWh,
+        homeKWh: row.homeKWh,
+        gridExport: row.gridExport,
+      };
+    }
     return acc;
   }, {
     totalSolar: 0,
@@ -147,6 +157,7 @@ export function selectKpiMetrics(state){
     avgDailyUse,
     avgDailyProd,
     selfSufficiency,
+    topProductionDay,
   };
 }
 


### PR DESCRIPTION
## Summary
- add a top production day card to the KPI tab that surfaces the highest solar production day with usage/export context
- extend the KPI metrics selector to compute the top production day from the loaded daily dataset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d708edcf90832992efcd3da850e616