### PR TITLE
Update KPI comparison labels

### DIFF
--- a/tabs/kpi.js
+++ b/tabs/kpi.js
@@ -17,12 +17,12 @@ export async function mount(root, ctx){
         <div class="card">
           <div class="kpi" id="kpiWeekToDate">0 kWh</div>
           <div class="kpi-label">WTD Solar</div>
-          <div class="text-xs text-slate-500" id="kpiWeekToDateDetail">vs same period last week</div>
+          <div class="text-xs text-slate-500" id="kpiWeekToDateDetail">vs PWTD</div>
         </div>
         <div class="card">
           <div class="kpi" id="kpiMonthToDate">0 kWh</div>
           <div class="kpi-label">MTD Solar</div>
-          <div class="text-xs text-slate-500" id="kpiMonthToDateDetail">vs same period last month</div>
+          <div class="text-xs text-slate-500" id="kpiMonthToDateDetail">vs PMTD</div>
         </div>
       </div>
       <div class="grid grid-cols-2 gap-3">
@@ -139,8 +139,8 @@ async function loadKPIs(ctx){
     $root.querySelector('#kpiSelfSufficiency').textContent = fmtPct(metrics.selfSufficiency);
     $root.querySelector('#kpiAvgDailyUse').textContent     = fmtKWh(metrics.avgDailyUse);
     $root.querySelector('#kpiAvgDailyProd').textContent    = fmtKWh(metrics.avgDailyProd);
-    $root.querySelector('#kpiWeekToDateDetail').textContent  = formatDeltaDetail(metrics.weekToDate, 'same period last week');
-    $root.querySelector('#kpiMonthToDateDetail').textContent = formatDeltaDetail(metrics.monthToDate, 'same period last month');
+    $root.querySelector('#kpiWeekToDateDetail').textContent  = formatDeltaDetail(metrics.weekToDate, 'PWTD');
+    $root.querySelector('#kpiMonthToDateDetail').textContent = formatDeltaDetail(metrics.monthToDate, 'PMTD');
 
     const top = metrics.topProductionDay;
     const topValueEl = $root.querySelector('#kpiTopProdValue');


### PR DESCRIPTION
## Summary
- rename the week-to-date comparison label to PWTD
- rename the month-to-date comparison label to PMTD

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b9672d5083298347443b7e716803