### PR TITLE
Align KPI card widths

### DIFF
--- a/tabs/kpi.js
+++ b/tabs/kpi.js
@@ -13,7 +13,7 @@ export async function mount(root, ctx){
   $root.innerHTML = `
     <section class="space-y-3" data-kpi-root>
       <div data-range-host></div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div class="grid grid-cols-2 gap-3">
         <div class="card">
           <div class="kpi" id="kpiWeekToDate">0 kWh</div>
           <div class="kpi-label">WTD Solar</div>


### PR DESCRIPTION
## Summary
- match the week-to-date and month-to-date KPI card grid to the total usage layout so the cards share the same width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e2ab598c83299a30cd777fdacce0