### PR TITLE
Add PWTD change KPI card

### DIFF
--- a/tabs/kpi.js
+++ b/tabs/kpi.js
@@ -13,11 +13,16 @@ export async function mount(root, ctx){
   $root.innerHTML = `
     <section class="space-y-3" data-kpi-root>
       <div data-range-host></div>
-      <div class="grid grid-cols-2 gap-3">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div class="card">
           <div class="kpi" id="kpiWeekToDate">0 kWh</div>
           <div class="kpi-label">WTD Solar</div>
           <div class="text-xs text-slate-500" id="kpiWeekToDateDetail">vs Pr</div>
+        </div>
+        <div class="card">
+          <div class="kpi" id="kpiPrevWeekChange">0%</div>
+          <div class="kpi-label">PWTD Change</div>
+          <div class="text-xs text-slate-500" id="kpiPrevWeekTotal">PWTD 0 kWh</div>
         </div>
         <div class="card">
           <div class="kpi" id="kpiMonthToDate">0 kWh</div>
@@ -134,6 +139,8 @@ async function loadKPIs(ctx){
     // Paint
     $root.querySelector('#kpiWeekToDate').textContent     = fmtKWh(metrics.weekToDate.value);
     $root.querySelector('#kpiMonthToDate').textContent    = fmtKWh(metrics.monthToDate.value);
+    $root.querySelector('#kpiPrevWeekChange').textContent = formatDeltaPercent(metrics.weekToDate.delta, metrics.weekToDate.previous);
+    $root.querySelector('#kpiPrevWeekTotal').textContent  = `PWTD ${fmtKWh(metrics.weekToDate.previous)}`;
     $root.querySelector('#kpiUsage').textContent           = fmtKWh(metrics.totalUse);
     $root.querySelector('#kpiSolar').textContent           = fmtKWh(metrics.totalSolar);
     $root.querySelector('#kpiImport').textContent          = fmtKWh(metrics.totalImp);


### PR DESCRIPTION
## Summary
- add a new PWTD change KPI card alongside the WTD and MTD production metrics
- populate the card with the percent change versus the prior week-to-date total and display the PWTD kWh total
- adjust the KPI grid layout to accommodate the additional card on larger screens

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9962b28008329b4bd2f7bbdd53025