### PR TITLE
Add PMTD and PYTD KPI cards with global data metrics

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -19,7 +19,7 @@ This repository contains a mobile-first progressive web application (PWA) for tr
 
 Each tab mounts into the shared `<main id="view">` element and drives its own UI:
 
-- **kpi.js** – Reads the cached daily dataset, calculates summary metrics (total usage/solar, grid import/export, self-sufficiency, and average daily values), and renders them as headline KPIs.
+- **kpi.js** – Reads the cached daily dataset, calculates summary metrics (total usage/solar, grid import/export, self-sufficiency, and average daily values), and renders them as headline KPIs. The WTD, PWTD, MTD, PMTD, YTD, and PYTD tiles now draw from the full historical dataset (ignoring the active date filter) and surface change cards for PWTD, PMTD, and PYTD next to their base totals.
 - **charts.js** – Uses the shared daily dataset selectors to render monthly stacked bars plus a sliding 7-day daily view. Includes a manual refresh button, change log, and slider to adjust the daily window.
 - **data.js** – Presents a sortable table of raw combined data (date, solar kWh, home kWh, net, grid import/export) for the selected range using the cached dataset. Shows helpful status messages when the range is empty or a backend request fails.
 - **record.js** – Allows manual entry of production readings. Displays the latest recorded values from Google Apps Script and submits form data back to the same endpoint, logging responses for troubleshooting.


### PR DESCRIPTION
## Summary
- add PMTD and PYTD change KPI cards and rename the YTD solar summary to match the new layout
- ensure week/month/year KPI tiles use the full historical dataset regardless of the active date filter
- update the project overview to reflect the new KPI behavior

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d999248a4c8329b0695b6516aeee1e