### PR TITLE
Add divider between KPI sections

### DIFF
--- a/tabs/kpi.js
+++ b/tabs/kpi.js
@@ -35,6 +35,7 @@ export async function mount(root, ctx){
           <div class="text-xs text-slate-500" id="kpiPrevMonthTotal">PMTD 0 kWh</div>
         </div>
       </div>
+      <hr class="my-2 border-t border-slate-200 dark:border-slate-700" />
       <div class="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-5">
         <div class="card"><div class="kpi" id="kpiYtdSolar">0 kWh</div><div class="kpi-label">YTD Solar</div></div>
         <div class="card">


### PR DESCRIPTION
## Summary
- insert a horizontal rule between the WTD/MTD and YTD KPI groups to better delineate the sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99e73b1d8832982c4f2f2ab1526ef