### PR TITLE
Expand KPI data window for accurate YTD metrics

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -11,7 +11,7 @@ This repository contains a mobile-first progressive web application (PWA) for tr
 
 ## Shared Utilities
 
-- **tabs/date-range.js** – Hosts reusable helpers for rendering the date range picker UI and normalizing the selected start/end dates for BigQuery-style SQL queries.
+- **tabs/date-range.js** – Hosts reusable helpers for rendering the date range picker UI and normalizing the selected start/end dates for BigQuery-style SQL queries. The default range now begins on 2024-01-01 so the KPI tab can calculate both the current and prior year-to-date aggregates without triggering a second network round-trip.
 - **tabs/cloud-config.js** – Exposes the OAuth client ID, Cloud Storage bucket information, and default BigQuery settings (including the US multi-region location) used anywhere Google Cloud access is required (entry and settings tabs).
 - **tabs/daily-data-store.js** – Centralizes loading of the combined solar/usage daily dataset, caches the results in shared state per date range, and exposes selectors for KPIs, charts, and tables so presentation tabs can stay lean.
 

--- a/tabs/date-range.js
+++ b/tabs/date-range.js
@@ -1,6 +1,13 @@
 const DAY_MS = 86400000;
 export const DEFAULT_WINDOW_DAYS = 30;
-const INITIAL_START_DATE = '2025-06-01';
+// Default to the beginning of the prior year so that KPIs such as
+// year-to-date (YTD) and prior year-to-date (PYTD) have the full
+// historical window they need to render meaningful comparisons.
+// Without this wider aperture the KPI tab only had access to data
+// from mid-2025 onward, which caused the YTD tile to under-report
+// production and left the PYTD change card with "n/a".  Loading the
+// full trailing 21 months gives both metrics the correct totals.
+const INITIAL_START_DATE = '2024-01-01';
 
 function getToday(){
   const today = new Date();


### PR DESCRIPTION
## Summary
- widen the default historical range to start on 2024-01-01 so KPI YTD/PYTD cards have full context
- document the broader default range in the project overview for future contributors

## Testing
- No automated tests were run (not available in project)

------
https://chatgpt.com/codex/tasks/task_e_68dac62f8d0c83299c8fdc5010931b7e